### PR TITLE
Added and fixed some protocols violations

### DIFF
--- a/vcl/rules/protocol.vcl
+++ b/vcl/rules/protocol.vcl
@@ -49,7 +49,7 @@ sub vcl_recv {
         set req.http.X-VSF-RuleID = "protocol.clen-1";
         call sec_handler;
     }
-    
+
     # Non numeric Content-Length Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
     # - http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
@@ -58,22 +58,22 @@ sub vcl_recv {
         set req.http.X-VSF-RuleID = "protocol.clen-2";
         call sec_handler;
     }
-    
-	# Require Content-Length to be provided with every POST request in a HTTP/1.1 request
-	# - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
-	if (req.method == "POST" && req.proto == "HTTP/1.1" && !req.http.Transfer-Encoding && !req.http.Content-Length) {
+
+    # Require Content-Length to be provided with every POST request in a HTTP/1.1 request
+    # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
+    if (req.method == "POST" && req.proto == "HTTP/1.1" && !req.http.Transfer-Encoding && !req.http.Content-Length) {
         set req.http.X-VSF-RuleName = "Empty Content-Length Header";
         set req.http.X-VSF-RuleID = "protocol.clen-3";
         call sec_handler;
-	}
-    
-	# Do not accept GET or HEAD requests with bodies
-	# - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
-	if (req.method ~ "^(GET|HEAD)$" && req.http.Content-Length && req.http.Content-Length !~ "^0*$") {
+    }
+
+    # Do not accept GET or HEAD requests with bodies
+    # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
+    if (req.method ~ "^(GET|HEAD)$" && req.http.Content-Length && req.http.Content-Length !~ "^0*$") {
         set req.http.X-VSF-RuleName = "GET or HEAD requests with bodies";
         set req.http.X-VSF-RuleID = "protocol.clen-4";
         call sec_handler;
-	}
+    }
 
     # POST without Content-Type Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
@@ -82,7 +82,7 @@ sub vcl_recv {
         set req.http.X-VSF-RuleID = "protocol.ctype-1";
         call sec_handler;
     }
-    
+
     # Not Expected Header on HTTP/1.0
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
     # - http://www.bad-behavior.ioerror.us/documentation/how-it-works/

--- a/vcl/rules/protocol.vcl
+++ b/vcl/rules/protocol.vcl
@@ -17,11 +17,12 @@ sub vcl_recv {
 
     # Empty Accept Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_21_protocol_anomalies.conf)
-    if (req.http.Accept && req.http.Accept ~ "^ *$") {
-        set req.http.X-VSF-RuleName = "Empty Accept Header";
-        set req.http.X-VSF-RuleID = "protocol.accpt-1";
-        call sec_handler;
-    }
+    # Many false/positive - Several good bots send request without Accept Header
+    #if (req.http.Accept && req.http.Accept ~ "^ *$") {
+    #    set req.http.X-VSF-RuleName = "Empty Accept Header";
+    #    set req.http.X-VSF-RuleID = "protocol.accpt-1";
+    #    call sec_handler;
+    #}
 
     # Empty User-Agent Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_21_protocol_anomalies.conf)
@@ -40,15 +41,15 @@ sub vcl_recv {
         call sec_handler;
     }
 
-    # POST without Content-Length Header
+    # POST without Content-Length Header in a HTTP/1.0 request
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
     # - http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5
-    if (req.method == "POST" && req.http.Content-Length && req.http.Content-Length ~ "^0*$") {
+    if (req.method == "POST" && req.proto == "HTTP/1.0" && req.http.Content-Length && req.http.Content-Length ~ "^0*$") {
         set req.http.X-VSF-RuleName = "Empty Content-Length Header";
         set req.http.X-VSF-RuleID = "protocol.clen-1";
         call sec_handler;
     }
-
+    
     # Non numeric Content-Length Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
     # - http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
@@ -57,19 +58,35 @@ sub vcl_recv {
         set req.http.X-VSF-RuleID = "protocol.clen-2";
         call sec_handler;
     }
+    
+	# Require Content-Length to be provided with every POST request in a HTTP/1.1 request
+	# - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
+	if (req.method == "POST" && req.proto == "HTTP/1.1" && !req.http.Transfer-Encoding && !req.http.Content-Length) {
+        set req.http.X-VSF-RuleName = "Empty Content-Length Header";
+        set req.http.X-VSF-RuleID = "protocol.clen-3";
+        call sec_handler;
+	}
+    
+	# Do not accept GET or HEAD requests with bodies
+	# - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
+	if (req.method ~ "^(GET|HEAD)$" && req.http.Content-Length && req.http.Content-Length !~ "^0*$") {
+        set req.http.X-VSF-RuleName = "GET or HEAD requests with bodies";
+        set req.http.X-VSF-RuleID = "protocol.clen-4";
+        call sec_handler;
+	}
 
     # POST without Content-Type Header
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
-    if (req.method == "POST" && !req.http.Content-Type) {
+    if (req.method == "POST" && !req.http.Content-Type && req.http.Content-Length && req.http.Content-Length !~ "^0*$") {
         set req.http.X-VSF-RuleName = "Empty Content-Type Header";
         set req.http.X-VSF-RuleID = "protocol.ctype-1";
         call sec_handler;
     }
-
-    # Expected Header on HTTP < 1.1
+    
+    # Not Expected Header on HTTP/1.0
     # - http://mod-security.svn.sourceforge.net/ (modsecurity_crs_20_protocol_violations.conf)
     # - http://www.bad-behavior.ioerror.us/documentation/how-it-works/
-    if (req.http.Expect && req.proto != "HTTP/1.1") {
+    if (req.http.Expect && req.proto == "HTTP/1.0") {
         set req.http.X-VSF-RuleName = "Expect Header is Allowed Only on HTTP/1.1";
         set req.http.X-VSF-RuleID = "protocol.expctd-1";
         call sec_handler;


### PR DESCRIPTION
Changes:
- POST without Content-Length Header: This rule is just for HTTP/1.0
- POST without Content-Type Header: It is not mandatory, requiring only if there is Content-Length
- Expected Header on HTTP < 1.1 (Not Expected Header on HTTP/1.0): If the protocol update some day, it will be a mess, huh?

Added:
- Require Content-Length to be provided with every POST request in a HTTP/1.1 request
- Do not accept GET or HEAD requests with bodies

Removed:
- Empty Accept Header: Many false/positive - Many good bots send request without Accept header. Only this rule should not be used to block the request.